### PR TITLE
fixed the bug in tree map and added location of Uganda tree planting in plant_a_tree.html

### DIFF
--- a/webpages/plant_a_tree.html
+++ b/webpages/plant_a_tree.html
@@ -54,6 +54,7 @@
       <h2>
         Uganda
       </h2>
+       Location: Kabale District 
       <table>
         <thead>
           <tr>
@@ -412,15 +413,18 @@
     },
     onRegionSelected: function (index, isSelected, selectedRegions) {
       console.log(index, isSelected, selectedRegions);
+      var e1 = document.querySelector(".uganda");
+      var e2 = document.querySelector(".kenya");
+      var e3 = document.querySelector(".tanzania");
       // enable certain regions
       if (['UG', 'TZ', 'KE'].indexOf(index) < 0) {
         worldMap.clearSelectedRegions();
         worldMap.removeMarkers();
         worldMap.setFocus();
+        e1.classList.remove("show");
+        e2.classList.remove("show");
+        e3.classList.remove("show");
       } else {
-        var e1 = document.querySelector(".uganda");
-        var e2 = document.querySelector(".kenya");
-        var e3 = document.querySelector(".tanzania");
         switch (index) {
           case 'UG':
             e1.classList.add("show");


### PR DESCRIPTION
# Description

fix: 1. fixed the bug in tree map that information about the think tree division was still displayed when clicking on a region other than think tree divisions.
2. added location of Uganda tree planting info in tree map.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas